### PR TITLE
add bcgovr attribution footer to template files

### DIFF
--- a/inst/templates/CONTRIBUTING.md
+++ b/inst/templates/CONTRIBUTING.md
@@ -6,3 +6,6 @@ Government employees, public and members of the private sector are encouraged to
 Pull requests will be evaluated by the repository guardians on a schedule and if deemed beneficial will be committed to the master.
 
 All contributors retain the original copyright to their stuff, but by contributing to this project, you grant a world-wide, royalty-free, perpetual, irrevocable, non-exclusive, transferable license to all users **under the terms of the license under which this project is distributed.**
+
+---
+*This project was created by the [bcgovr](https://github.com/bcgov/bcgovr) package.*

--- a/inst/templates/CONTRIBUTING.md
+++ b/inst/templates/CONTRIBUTING.md
@@ -8,4 +8,4 @@ Pull requests will be evaluated by the repository guardians on a schedule and if
 All contributors retain the original copyright to their stuff, but by contributing to this project, you grant a world-wide, royalty-free, perpetual, irrevocable, non-exclusive, transferable license to all users **under the terms of the license under which this project is distributed.**
 
 ---
-*This project was created by the [bcgovr](https://github.com/bcgov/bcgovr) package.*
+*This project was created using the [bcgovr](https://github.com/bcgov/bcgovr) package.*

--- a/inst/templates/CoC.md
+++ b/inst/templates/CoC.md
@@ -47,3 +47,6 @@ version 1.3.0, available at
 
 [homepage]: http://contributor-covenant.org
 [version]: http://contributor-covenant.org/version/1/3/0/
+
+---
+*This project was created by the [bcgovr](https://github.com/bcgov/bcgovr) package.*

--- a/inst/templates/CoC.md
+++ b/inst/templates/CoC.md
@@ -49,4 +49,4 @@ version 1.3.0, available at
 [version]: http://contributor-covenant.org/version/1/3/0/
 
 ---
-*This project was created by the [bcgovr](https://github.com/bcgov/bcgovr) package.*
+*This project was created using the [bcgovr](https://github.com/bcgov/bcgovr) package.*

--- a/inst/templates/README.Rmd
+++ b/inst/templates/README.Rmd
@@ -54,3 +54,6 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 ```
 {{licence_text}}
 ```
+
+---
+*This project was created by the [bcgovr](https://github.com/bcgov/bcgovr) package.* 

--- a/inst/templates/README.Rmd
+++ b/inst/templates/README.Rmd
@@ -56,4 +56,4 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 ```
 
 ---
-*This project was created by the [bcgovr](https://github.com/bcgov/bcgovr) package.* 
+*This project was created using the [bcgovr](https://github.com/bcgov/bcgovr) package.* 

--- a/inst/templates/README.md
+++ b/inst/templates/README.md
@@ -45,5 +45,5 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 {{licence_text}}
 ```
 ---
-*This project was created by the [bcgovr](https://github.com/bcgov/bcgovr) package.* 
+*This project was created using the [bcgovr](https://github.com/bcgov/bcgovr) package.* 
 

--- a/inst/templates/README.md
+++ b/inst/templates/README.md
@@ -44,3 +44,6 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 ```
 {{licence_text}}
 ```
+---
+*This project was created by the [bcgovr](https://github.com/bcgov/bcgovr) package.* 
+

--- a/inst/templates/pkg-README.Rmd
+++ b/inst/templates/pkg-README.Rmd
@@ -53,3 +53,5 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 {{licence_text}}
 ```
 
+---
+*This project was created by the [bcgovr](https://github.com/bcgov/bcgovr) package.* 

--- a/inst/templates/pkg-README.Rmd
+++ b/inst/templates/pkg-README.Rmd
@@ -54,4 +54,4 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 ```
 
 ---
-*This project was created by the [bcgovr](https://github.com/bcgov/bcgovr) package.* 
+*This project was created using the [bcgovr](https://github.com/bcgov/bcgovr) package.* 

--- a/inst/templates/pkg-README.md
+++ b/inst/templates/pkg-README.md
@@ -42,4 +42,6 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 {{licence_text}}
 ```
 
+---
+*This project was created by the [bcgovr](https://github.com/bcgov/bcgovr) package.* 
 

--- a/inst/templates/pkg-README.md
+++ b/inst/templates/pkg-README.md
@@ -43,5 +43,5 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 ```
 
 ---
-*This project was created by the [bcgovr](https://github.com/bcgov/bcgovr) package.* 
+*This project was created using the [bcgovr](https://github.com/bcgov/bcgovr) package.* 
 


### PR DESCRIPTION
Thoughts on wording? Trying to keep it basic. I have also opted not to include the mini bcgovr logo as I think it adds a little too much overhead to a potential project using bcgovr. 